### PR TITLE
Messages on too old version and unreachable docker daemon

### DIFF
--- a/dockerbeat_test.go
+++ b/dockerbeat_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+// helper method
+func getEmptyDockerbeat() Dockerbeat {
+	return Dockerbeat{
+		false,
+		time.Duration(10),
+		"/fake/path/to/socket.sock",
+		ConfigSettings{
+			DockerConfig{nil, nil},
+		},
+		nil,
+		nil,
+		EventGenerator{
+			map[string]NetworkData{},
+			map[string]BlkioStats{},
+		},
+	}
+}
+
+func TestDockerbeatValidVersionTooOld(t *testing.T) {
+	// GIVEN
+	var versions = []string{"1.3.0", "1.4.2", "1.4.9"}
+	var beat = getEmptyDockerbeat()
+
+	for _, version := range versions {
+		// WHEN
+		var valid, err = beat.validVersion(version)
+
+		// THEN
+		assert.False(t, valid)
+		assert.Nil(t, err)
+	}
+}
+
+func TestDockerbeatValidVersionMalformed(t *testing.T) {
+	// GIVEN
+	var versions = []string{"1.xD", "malformed", "1.5-testMalformed"}
+	var beat = getEmptyDockerbeat()
+
+	for _, version := range versions {
+		// WHEN
+		var valid, err = beat.validVersion(version)
+
+		// THEN
+		assert.False(t, valid)
+		assert.NotNil(t, err)
+	}
+}
+
+func TestDockerbeatValidVersion(t *testing.T) {
+	// GIVEN
+	var versions = []string{"1.5.0", "1.5.3", "1.6.12"}
+	var beat = getEmptyDockerbeat()
+
+	for _, version := range versions {
+		// WHEN
+		var valid, err = beat.validVersion(version)
+
+		// THEN
+		assert.True(t, valid)
+		assert.Nil(t, err)
+	}
+}

--- a/dockerbeat_test.go
+++ b/dockerbeat_test.go
@@ -21,6 +21,7 @@ func getEmptyDockerbeat() Dockerbeat {
 			map[string]NetworkData{},
 			map[string]BlkioStats{},
 		},
+		SoftwareVersion{1, 5},
 	}
 }
 
@@ -56,7 +57,7 @@ func TestDockerbeatValidVersionMalformed(t *testing.T) {
 
 func TestDockerbeatValidVersion(t *testing.T) {
 	// GIVEN
-	var versions = []string{"1.5.0", "1.5.3", "1.6.12"}
+	var versions = []string{"1.5.0", "1.5.3", "1.6.12", "1.8.2"}
 	var beat = getEmptyDockerbeat()
 
 	for _, version := range versions {

--- a/eventgenerator.go
+++ b/eventgenerator.go
@@ -3,8 +3,8 @@ package main
 import (
 	"github.com/elastic/libbeat/common"
 	"github.com/fsouza/go-dockerclient"
-	"time"
 	"strings"
+	"time"
 )
 
 type EventGenerator struct {
@@ -14,9 +14,9 @@ type EventGenerator struct {
 
 func (d *EventGenerator) getContainerEvent(container *docker.APIContainers, stats *docker.Stats) common.MapStr {
 	event := common.MapStr{
-		"timestamp":      common.Time(stats.Read),
-		"type":           "container",
-		"containerID":    container.ID,
+		"timestamp":     common.Time(stats.Read),
+		"type":          "container",
+		"containerID":   container.ID,
 		"containerName": d.extractContainerName(container.Names),
 		"container": common.MapStr{
 			"id":         container.ID,
@@ -42,9 +42,9 @@ func (d *EventGenerator) getCpuEvent(container *docker.APIContainers, stats *doc
 	}
 
 	event := common.MapStr{
-		"timestamp":      common.Time(stats.Read),
-		"type":           "cpu",
-		"containerID":    container.ID,
+		"timestamp":     common.Time(stats.Read),
+		"type":          "cpu",
+		"containerID":   container.ID,
 		"containerName": d.extractContainerName(container.Names),
 		"cpu": common.MapStr{
 			"percpuUsage":       calculator.perCpuUsage(),
@@ -77,9 +77,9 @@ func (d *EventGenerator) getNetworkEvent(container *docker.APIContainers, stats 
 	if ok {
 		calculator := NetworkCalculator{oldNetworkData, newNetworkData}
 		event = common.MapStr{
-			"timestamp":      common.Time(stats.Read),
-			"type":           "net",
-			"containerID":    container.ID,
+			"timestamp":     common.Time(stats.Read),
+			"type":          "net",
+			"containerID":   container.ID,
 			"containerName": d.extractContainerName(container.Names),
 			"net": common.MapStr{
 				"rxBytes_ps":   calculator.getRxBytesPerSecond(),
@@ -94,9 +94,9 @@ func (d *EventGenerator) getNetworkEvent(container *docker.APIContainers, stats 
 		}
 	} else {
 		event = common.MapStr{
-			"timestamp":      common.Time(stats.Read),
-			"type":           "net",
-			"containerID":    container.ID,
+			"timestamp":     common.Time(stats.Read),
+			"type":          "net",
+			"containerID":   container.ID,
 			"containerName": d.extractContainerName(container.Names),
 			"net": common.MapStr{
 				"rxBytes_ps":   0,
@@ -117,9 +117,9 @@ func (d *EventGenerator) getNetworkEvent(container *docker.APIContainers, stats 
 
 func (d *EventGenerator) getMemoryEvent(container *docker.APIContainers, stats *docker.Stats) common.MapStr {
 	event := common.MapStr{
-		"timestamp":      common.Time(stats.Read),
-		"type":           "memory",
-		"containerID":    container.ID,
+		"timestamp":     common.Time(stats.Read),
+		"type":          "memory",
+		"containerID":   container.ID,
 		"containerName": d.extractContainerName(container.Names),
 		"memory": common.MapStr{
 			"failcnt":  stats.MemoryStats.Failcnt,

--- a/eventgenerator_test.go
+++ b/eventgenerator_test.go
@@ -38,9 +38,9 @@ func TestEventGeneratorGetContainerEvent(t *testing.T) {
 
 	// expected output
 	expectedEvent := common.MapStr{
-		"timestamp":      common.Time(timestamp),
-		"type":           "container",
-		"containerID":    container.ID,
+		"timestamp":     common.Time(timestamp),
+		"type":          "container",
+		"containerID":   container.ID,
 		"containerName": "name1",
 		"container": common.MapStr{
 			"id":      container.ID,


### PR DESCRIPTION
To behaviors:

* *on startup* (Setup method), if docker daemon is too old or unreachable, then dockerbeat shuts down after it logs a message
* *in the main loop* (Run method), if docker daemon become too old (xD) or unreachable, then a message is logged as Error level