### PR TITLE
Update Dockerfile to work with beat dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ COPY . /go/src/github.com/ingensi/dockerbeat
 RUN cd /go/src/github.com/ingensi/dockerbeat && make
 
 RUN mkdir -p /etc/dockerbeat/ \
-    && cp /usr/src/dockerbeat/dockerbeat /etc/dockerbeat/ \
-    && cp /usr/src/dockerbeat/etc/dockerbeat-docker.yml /etc/dockerbeat/dockerbeat.yml \
-    && rm -rf /usr/src/dockerbeat
+    && cp /go/src/github.com/ingensi/dockerbeat/dockerbeat /etc/dockerbeat/ \
+    && cp /go/src/github.com/ingensi/dockerbeat/dockerbeat-docker.yml /etc/dockerbeat/dockerbeat.yml
 
 WORKDIR /etc/dockerbeat
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.5.1
 MAINTAINER Ingensi labs <contact@ingensi.com>
 
-COPY . /usr/src/dockerbeat
-RUN cd /usr/src/dockerbeat && make
+COPY . /go/src/github.com/ingensi/dockerbeat
+RUN cd /go/src/github.com/ingensi/dockerbeat && make
 
 RUN mkdir -p /etc/dockerbeat/ \
     && cp /usr/src/dockerbeat/dockerbeat /etc/dockerbeat/ \


### PR DESCRIPTION
main.go beat dependency does not work if project is not in $GOPATH.

This PR resolves this issue by copying project into $GOPATH