### PR TITLE
Add containers RSS memory usage in beats.

### DIFF
--- a/beat/EventGenerator.go
+++ b/beat/EventGenerator.go
@@ -175,11 +175,13 @@ func (d *EventGenerator) getMemoryEvent(container *docker.APIContainers, stats *
 		"containerName": d.extractContainerName(container.Names),
 		"dockerSocket":  d.socket,
 		"memory": common.MapStr{
-			"failcnt":  stats.MemoryStats.Failcnt,
-			"limit":    stats.MemoryStats.Limit,
-			"maxUsage": stats.MemoryStats.MaxUsage,
-			"usage":    stats.MemoryStats.Usage,
-			"usage_p":  float64(stats.MemoryStats.Usage) / float64(stats.MemoryStats.Limit),
+			"totalRss":   stats.MemoryStats.Stats.TotalRss,
+			"totalRss_p": float64(stats.MemoryStats.Stats.TotalRss) / float64(stats.MemoryStats.Limit),
+			"failcnt":    stats.MemoryStats.Failcnt,
+			"limit":      stats.MemoryStats.Limit,
+			"maxUsage":   stats.MemoryStats.MaxUsage,
+			"usage":      stats.MemoryStats.Usage,
+			"usage_p":    float64(stats.MemoryStats.Usage) / float64(stats.MemoryStats.Limit),
 		},
 	}
 

--- a/beat/EventGenerator.go
+++ b/beat/EventGenerator.go
@@ -175,11 +175,11 @@ func (d *EventGenerator) getMemoryEvent(container *docker.APIContainers, stats *
 		"containerName": d.extractContainerName(container.Names),
 		"dockerSocket":  d.socket,
 		"memory": common.MapStr{
-			"totalRss":   stats.MemoryStats.Stats.TotalRss,
-			"totalRss_p": float64(stats.MemoryStats.Stats.TotalRss) / float64(stats.MemoryStats.Limit),
 			"failcnt":    stats.MemoryStats.Failcnt,
 			"limit":      stats.MemoryStats.Limit,
 			"maxUsage":   stats.MemoryStats.MaxUsage,
+			"totalRss":   stats.MemoryStats.Stats.TotalRss,
+			"totalRss_p": float64(stats.MemoryStats.Stats.TotalRss) / float64(stats.MemoryStats.Limit),
 			"usage":      stats.MemoryStats.Usage,
 			"usage_p":    float64(stats.MemoryStats.Usage) / float64(stats.MemoryStats.Limit),
 		},

--- a/beat/EventGenerator_test.go
+++ b/beat/EventGenerator_test.go
@@ -802,11 +802,11 @@ func TestEventGeneratorGetMemoryEvent(t *testing.T) {
 		"containerName": "name1",
 		"dockerSocket":  &socket,
 		"memory": common.MapStr{
-			"totalRss":   stats.MemoryStats.Stats.TotalRss,
-			"totalRss_p": float64(stats.MemoryStats.Stats.TotalRss) / float64(stats.MemoryStats.Limit),
 			"failcnt":    stats.MemoryStats.Failcnt,
 			"limit":      stats.MemoryStats.Limit,
 			"maxUsage":   stats.MemoryStats.MaxUsage,
+			"totalRss":   stats.MemoryStats.Stats.TotalRss,
+			"totalRss_p": float64(stats.MemoryStats.Stats.TotalRss) / float64(stats.MemoryStats.Limit),
 			"usage":      stats.MemoryStats.Usage,
 			"usage_p":    float64(stats.MemoryStats.Usage) / float64(stats.MemoryStats.Limit),
 		},
@@ -1283,7 +1283,7 @@ func getMemoryStats(read time.Time, number uint64) docker.Stats {
 		Limit    uint64 `json:"limit,omitempty" yaml:"limit,omitempty"`
 	}
 
-	return docker.Stats{
+	testStats := docker.Stats{
 		Read: read,
 		MemoryStats: memoryStats{
 			MaxUsage: number,
@@ -1291,7 +1291,11 @@ func getMemoryStats(read time.Time, number uint64) docker.Stats {
 			Failcnt:  number * 3,
 			Limit:    number * 4,
 		},
-	}
+	};
+	
+	testStats.MemoryStats.Stats.TotalRss = number * 5;
+	
+	return testStats;
 }
 
 func getMockedBlkioCalculator(number float64) *MockedBlkioCalculator {

--- a/beat/EventGenerator_test.go
+++ b/beat/EventGenerator_test.go
@@ -802,11 +802,13 @@ func TestEventGeneratorGetMemoryEvent(t *testing.T) {
 		"containerName": "name1",
 		"dockerSocket":  &socket,
 		"memory": common.MapStr{
-			"failcnt":  stats.MemoryStats.Failcnt,
-			"limit":    stats.MemoryStats.Limit,
-			"maxUsage": stats.MemoryStats.MaxUsage,
-			"usage":    stats.MemoryStats.Usage,
-			"usage_p":  float64(stats.MemoryStats.Usage) / float64(stats.MemoryStats.Limit),
+			"totalRss":   stats.MemoryStats.Stats.TotalRss,
+			"totalRss_p": float64(stats.MemoryStats.Stats.TotalRss) / float64(stats.MemoryStats.Limit),
+			"failcnt":    stats.MemoryStats.Failcnt,
+			"limit":      stats.MemoryStats.Limit,
+			"maxUsage":   stats.MemoryStats.MaxUsage,
+			"usage":      stats.MemoryStats.Usage,
+			"usage_p":    float64(stats.MemoryStats.Usage) / float64(stats.MemoryStats.Limit),
 		},
 	}
 

--- a/doc/fields.asciidoc
+++ b/doc/fields.asciidoc
@@ -308,6 +308,20 @@ type: float
 Maximum memory used by the container in Bytes.
 
 
+==== totalRss
+
+type: float
+
+"Current RSS (applications' Resident Set Size) memory consumption in Bytes."
+
+
+==== totalRss_p
+
+type: float
+
+"Current RSS (applications' Resident Set Size) memory consumption in percents between 0.0 and 1.0."
+
+
 ==== usage
 
 type: float

--- a/etc/dockerbeat.template.json
+++ b/etc/dockerbeat.template.json
@@ -177,6 +177,14 @@
               "doc_values": "true",
               "type": "float"
             },
+            "totalRss": {
+              "doc_values": "true",
+              "type": "float"
+            },
+            "totalRss_p": {
+              "doc_values": "true",
+              "type": "float"
+            },
             "usage": {
               "doc_values": "true",
               "type": "float"

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -220,7 +220,17 @@ memory:
           type: float
           description: >
             Maximum memory used by the container in Bytes.
+            
+        - name: totalRss
+          type: float
+          description: >
+            "Current RSS (applications' Resident Set Size) memory consumption in Bytes."
 
+        - name: totalRss_p
+          type: float
+          description: >
+            "Current RSS (applications' Resident Set Size) memory consumption in percents between 0.0 and 1.0."
+            
         - name: usage
           type: float
           description: >


### PR DESCRIPTION
Dockerbeat currently only reports the total used memory for each container, which not only contains the application's allocated memory, but also various caches.
As these caches are managed by the kernel, and usually fill up all the available memory, they are not very indicative of how much applications are actually consuming.

This commit adds the Resident-Set Size (RSS) of the containers to the generated beats, as well as the corresponding percentage, allowing for a more precise memory monitoring.