### PR TITLE
Set an entrypoint instead a command for the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ RUN mkdir -p /etc/dockerbeat/ \
     && cp /go/src/github.com/ingensi/dockerbeat/etc/dockerbeat-docker.yml /etc/dockerbeat/dockerbeat.yml
 
 WORKDIR /etc/dockerbeat
+ENTRYPOINT dockerbeat
 
-CMD [ "/usr/local/bin/dockerbeat", "-c", "dockerbeat.yml" ]
+CMD [ "-c", "dockerbeat.yml" ]


### PR DESCRIPTION
If you want to override some args to the run command, you need to rewrite `ingensi/dockerbeat ./dockerbeat -d "debug"` instead of just `ingensi/dockerbeat -d debug`.

This PR fix it.