### PR TITLE
Export labels for all type of event

### DIFF
--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -90,6 +90,26 @@ Name of the Beat sending the events. If the shipper name is set in the configura
 The hostname as returned by the operating system on which the Beat is running.
 
 
+=== labels Fields
+
+Array of label metadata of the Docker container.
+
+
+
+==== labels.key
+
+type: string
+
+Key of the container label.
+
+
+==== labels.value
+
+type: string
+
+Value of the container label.
+
+
 [[exported-fields-container]]
 === Container information Fields
 
@@ -131,11 +151,6 @@ ID of the Docker container.
 type: string
 
 Name of the Docker image from which contained has been launched.
-
-
-=== labels Fields
-
-Key value related to the label metadata of the Docker container.
 
 
 ==== container.names

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -80,6 +80,26 @@ required: True
 URI to the monitored docker daemon.
 
 
+=== containerLabels Fields
+
+Array of label metadata of the Docker container.
+
+
+
+==== containerLabels.key
+
+type: string
+
+Key of the container label.
+
+
+==== containerLabels.value
+
+type: string
+
+Value of the container label.
+
+
 ==== beat.name
 
 Name of the Beat sending the events. If the shipper name is set in the configuration file, then that value is used. If it is not set, the hostname is used.
@@ -88,26 +108,6 @@ Name of the Beat sending the events. If the shipper name is set in the configura
 ==== beat.hostname
 
 The hostname as returned by the operating system on which the Beat is running.
-
-
-=== labels Fields
-
-Array of label metadata of the Docker container.
-
-
-
-==== labels.key
-
-type: string
-
-Key of the container label.
-
-
-==== labels.value
-
-type: string
-
-Value of the container label.
 
 
 [[exported-fields-container]]

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -64,6 +64,21 @@ env:
         The hostname as returned by the operating system on which the Beat is
         running.
 
+    - name: labels
+      type: group
+      description: >
+        Array of label metadata of the Docker container.
+      fields:
+        - name: key
+          type: string
+          description: >
+            Key of the container label.
+
+        - name: value
+          type: string
+          description: >
+            Value of the container label.
+
 container:
   type: group
   description: >
@@ -93,12 +108,6 @@ container:
           type: string
           description: >
             Name of the Docker image from which contained has been launched.
-
-        - name: labels
-          type: group
-          description: >
-            Key value related to the label metadata of the Docker container.
-          fields: []
 
         - name: names
           type: string

--- a/etc/fields.yml
+++ b/etc/fields.yml
@@ -53,18 +53,7 @@ env:
         URI to the monitored docker daemon.
       required: true
 
-    - name: beat.name
-      description: >
-        Name of the Beat sending the events. If the shipper name is set
-        in the configuration file, then that value is used. If it is not set,
-        the hostname is used.
-
-    - name: beat.hostname
-      description: >
-        The hostname as returned by the operating system on which the Beat is
-        running.
-
-    - name: labels
+    - name: containerLabels
       type: group
       description: >
         Array of label metadata of the Docker container.
@@ -78,6 +67,17 @@ env:
           type: string
           description: >
             Value of the container label.
+
+    - name: beat.name
+      description: >
+        Name of the Beat sending the events. If the shipper name is set
+        in the configuration file, then that value is used. If it is not set,
+        the hostname is used.
+
+    - name: beat.hostname
+      description: >
+        The hostname as returned by the operating system on which the Beat is
+        running.
 
 container:
   type: group

--- a/event/generator.go
+++ b/event/generator.go
@@ -245,6 +245,7 @@ func (d *EventGenerator) GetBlkioEvent(container *docker.APIContainers, stats *d
 			"type":          "blkio",
 			"containerID":   container.ID,
 			"containerName": d.extractContainerName(container.Names),
+			"containerLabels":     d.buildLabelArray(container.Labels),
 			"dockerSocket":  d.Socket,
 			"blkio": common.MapStr{
 				"read_ps":  float64(0),
@@ -345,14 +346,17 @@ func (d *EventGenerator) expiredSavedData(date time.Time) bool {
 	return !date.Add(2 * d.Period).After(time.Now())
 }
 
-func (d *EventGenerator) buildLabelArray(labels map[string]string) []Label {
+func (d *EventGenerator) buildLabelArray(labels map[string]string) []common.MapStr {
 
-	output_labels := make([]Label, len(labels))
+	output_labels := make([]common.MapStr, len(labels))
 
 	i := 0
 	for k, v := range labels {
 		label := strings.Replace(k, ".", "_", -1)
-		output_labels[i] = Label{label, v}
+		output_labels[i] = common.MapStr{
+			"key" : label,
+			"value" : v,
+		}
 		i++
 	}
 

--- a/event/generator.go
+++ b/event/generator.go
@@ -34,12 +34,12 @@ type EventGenerator struct {
 
 func (d *EventGenerator) GetContainerEvent(container *docker.APIContainers, stats *docker.Stats) common.MapStr {
 	event := common.MapStr{
-		"@timestamp":    common.Time(stats.Read),
-		"type":          "container",
-		"containerID":   container.ID,
-		"containerName": d.extractContainerName(container.Names),
-		"containerLabels":     d.buildLabelArray(container.Labels),
-		"dockerSocket":  d.Socket,
+		"@timestamp":      common.Time(stats.Read),
+		"type":            "container",
+		"containerID":     container.ID,
+		"containerName":   d.extractContainerName(container.Names),
+		"containerLabels": d.buildLabelArray(container.Labels),
+		"dockerSocket":    d.Socket,
 		"container": common.MapStr{
 			"id":         container.ID,
 			"command":    container.Command,
@@ -73,12 +73,12 @@ func (d *EventGenerator) GetCpuEvent(container *docker.APIContainers, stats *doc
 	)
 
 	event := common.MapStr{
-		"@timestamp":    common.Time(stats.Read),
-		"type":          "cpu",
-		"containerID":   container.ID,
-		"containerName": d.extractContainerName(container.Names),
-		"containerLabels":     d.buildLabelArray(container.Labels),
-		"dockerSocket":  d.Socket,
+		"@timestamp":      common.Time(stats.Read),
+		"type":            "cpu",
+		"containerID":     container.ID,
+		"containerName":   d.extractContainerName(container.Names),
+		"containerLabels": d.buildLabelArray(container.Labels),
+		"dockerSocket":    d.Socket,
 		"cpu": common.MapStr{
 			"percpuUsage":       calculator.PerCpuUsage(),
 			"totalUsage":        calculator.TotalUsage(),
@@ -143,12 +143,12 @@ func (d *EventGenerator) GetNetworkEvent(container *docker.APIContainers, time t
 	if ok {
 		calculator := d.CalculatorFactory.NewNetworkCalculator(oldNetworkData, newNetworkData)
 		event = common.MapStr{
-			"@timestamp":    common.Time(time),
-			"type":          "net",
-			"containerID":   container.ID,
-			"containerName": d.extractContainerName(container.Names),
-			"containerLabels":     d.buildLabelArray(container.Labels),
-			"dockerSocket":  d.Socket,
+			"@timestamp":      common.Time(time),
+			"type":            "net",
+			"containerID":     container.ID,
+			"containerName":   d.extractContainerName(container.Names),
+			"containerLabels": d.buildLabelArray(container.Labels),
+			"dockerSocket":    d.Socket,
 			"net": common.MapStr{
 				"name":         network,
 				"rxBytes_ps":   calculator.GetRxBytesPerSecond(),
@@ -163,12 +163,12 @@ func (d *EventGenerator) GetNetworkEvent(container *docker.APIContainers, time t
 		}
 	} else {
 		event = common.MapStr{
-			"@timestamp":    common.Time(time),
-			"type":          "net",
-			"containerID":   container.ID,
-			"containerName": d.extractContainerName(container.Names),
-			"containerLabels":     d.buildLabelArray(container.Labels),
-			"dockerSocket":  d.Socket,
+			"@timestamp":      common.Time(time),
+			"type":            "net",
+			"containerID":     container.ID,
+			"containerName":   d.extractContainerName(container.Names),
+			"containerLabels": d.buildLabelArray(container.Labels),
+			"dockerSocket":    d.Socket,
 			"net": common.MapStr{
 				"name":         network,
 				"rxBytes_ps":   0,
@@ -195,12 +195,12 @@ func (d *EventGenerator) GetNetworkEvent(container *docker.APIContainers, time t
 
 func (d *EventGenerator) GetMemoryEvent(container *docker.APIContainers, stats *docker.Stats) common.MapStr {
 	event := common.MapStr{
-		"@timestamp":    common.Time(stats.Read),
-		"type":          "memory",
-		"containerID":   container.ID,
-		"containerName": d.extractContainerName(container.Names),
-		"containerLabels":     d.buildLabelArray(container.Labels),
-		"dockerSocket":  d.Socket,
+		"@timestamp":      common.Time(stats.Read),
+		"type":            "memory",
+		"containerID":     container.ID,
+		"containerName":   d.extractContainerName(container.Names),
+		"containerLabels": d.buildLabelArray(container.Labels),
+		"dockerSocket":    d.Socket,
 		"memory": common.MapStr{
 			"failcnt":    stats.MemoryStats.Failcnt,
 			"limit":      stats.MemoryStats.Limit,
@@ -227,12 +227,12 @@ func (d *EventGenerator) GetBlkioEvent(container *docker.APIContainers, stats *d
 	if ok {
 		calculator := d.CalculatorFactory.NewBlkioCalculator(oldBlkioStats, blkioStats)
 		event = common.MapStr{
-			"@timestamp":    common.Time(stats.Read),
-			"type":          "blkio",
-			"containerID":   container.ID,
-			"containerName": d.extractContainerName(container.Names),
-			"containerLabels":     d.buildLabelArray(container.Labels),
-			"dockerSocket":  d.Socket,
+			"@timestamp":      common.Time(stats.Read),
+			"type":            "blkio",
+			"containerID":     container.ID,
+			"containerName":   d.extractContainerName(container.Names),
+			"containerLabels": d.buildLabelArray(container.Labels),
+			"dockerSocket":    d.Socket,
 			"blkio": common.MapStr{
 				"read_ps":  calculator.GetReadPs(),
 				"write_ps": calculator.GetWritePs(),
@@ -241,12 +241,12 @@ func (d *EventGenerator) GetBlkioEvent(container *docker.APIContainers, stats *d
 		}
 	} else {
 		event = common.MapStr{
-			"@timestamp":    common.Time(stats.Read),
-			"type":          "blkio",
-			"containerID":   container.ID,
-			"containerName": d.extractContainerName(container.Names),
-			"containerLabels":     d.buildLabelArray(container.Labels),
-			"dockerSocket":  d.Socket,
+			"@timestamp":      common.Time(stats.Read),
+			"type":            "blkio",
+			"containerID":     container.ID,
+			"containerName":   d.extractContainerName(container.Names),
+			"containerLabels": d.buildLabelArray(container.Labels),
+			"dockerSocket":    d.Socket,
 			"blkio": common.MapStr{
 				"read_ps":  float64(0),
 				"write_ps": float64(0),
@@ -354,8 +354,8 @@ func (d *EventGenerator) buildLabelArray(labels map[string]string) []common.MapS
 	for k, v := range labels {
 		label := strings.Replace(k, ".", "_", -1)
 		output_labels[i] = common.MapStr{
-			"key" : label,
-			"value" : v,
+			"key":   label,
+			"value": v,
 		}
 		i++
 	}

--- a/event/generator_test.go
+++ b/event/generator_test.go
@@ -138,15 +138,15 @@ func TestEventGeneratorGetNetworksEventFirstPass(t *testing.T) {
 			"containerName": "name1",
 			"containerLabels": []common.MapStr{
 				common.MapStr{
-					"key" : "label1",
-					"value" : "value1",
+					"key":   "label1",
+					"value": "value1",
 				},
 				common.MapStr{
-					"key" : "label2",
-					"value" : "value2",
+					"key":   "label2",
+					"value": "value2",
 				},
 			},
-			"dockerSocket":  &socket,
+			"dockerSocket": &socket,
 			"net": common.MapStr{
 				"name":         "eth0",
 				"rxBytes_ps":   mockedNetworkCalculatorEth0.GetRxBytesPerSecond(),
@@ -165,15 +165,15 @@ func TestEventGeneratorGetNetworksEventFirstPass(t *testing.T) {
 			"containerName": "name1",
 			"containerLabels": []common.MapStr{
 				common.MapStr{
-					"key" : "label1",
-					"value" : "value1",
+					"key":   "label1",
+					"value": "value1",
 				},
 				common.MapStr{
-					"key" : "label2",
-					"value" : "value2",
+					"key":   "label2",
+					"value": "value2",
 				},
 			},
-			"dockerSocket":  &socket,
+			"dockerSocket": &socket,
 			"net": common.MapStr{
 				"name":         "em1",
 				"rxBytes_ps":   0,
@@ -353,15 +353,15 @@ func TestEventGeneratorGetNetworksEvent(t *testing.T) {
 			"containerName": "name1",
 			"containerLabels": []common.MapStr{
 				common.MapStr{
-					"key" : "label1",
-					"value" : "value1",
+					"key":   "label1",
+					"value": "value1",
 				},
 				common.MapStr{
-					"key" : "label2",
-					"value" : "value2",
+					"key":   "label2",
+					"value": "value2",
 				},
 			},
-			"dockerSocket":  &socket,
+			"dockerSocket": &socket,
 			"net": common.MapStr{
 				"name":         "eth0",
 				"rxBytes_ps":   mockedNetworkCalculatorEth0.GetRxBytesPerSecond(),
@@ -380,15 +380,15 @@ func TestEventGeneratorGetNetworksEvent(t *testing.T) {
 			"containerName": "name1",
 			"containerLabels": []common.MapStr{
 				common.MapStr{
-					"key" : "label1",
-					"value" : "value1",
+					"key":   "label1",
+					"value": "value1",
 				},
 				common.MapStr{
-					"key" : "label2",
-					"value" : "value2",
+					"key":   "label2",
+					"value": "value2",
 				},
 			},
-			"dockerSocket":  &socket,
+			"dockerSocket": &socket,
 			"net": common.MapStr{
 				"name":         "em1",
 				"rxBytes_ps":   mockedNetworkCalculatorEm1.GetRxBytesPerSecond(),
@@ -548,15 +548,15 @@ func TestEventGeneratorGetNetworksEventCleanSavedEvents(t *testing.T) {
 			"containerName": "name1",
 			"containerLabels": []common.MapStr{
 				common.MapStr{
-					"key" : "label1",
-					"value" : "value1",
+					"key":   "label1",
+					"value": "value1",
 				},
 				common.MapStr{
-					"key" : "label2",
-					"value" : "value2",
+					"key":   "label2",
+					"value": "value2",
 				},
 			},
-			"dockerSocket":  &socket,
+			"dockerSocket": &socket,
 			"net": common.MapStr{
 				"name":         "eth0",
 				"rxBytes_ps":   mockedNetworkCalculatorEth0.GetRxBytesPerSecond(),
@@ -635,19 +635,19 @@ func TestEventGeneratorGetContainerEvent(t *testing.T) {
 		"containerName": "name1",
 		"containerLabels": []common.MapStr{
 			common.MapStr{
-				"key" : "label1",
-				"value" : "value1",
+				"key":   "label1",
+				"value": "value1",
 			},
 			common.MapStr{
-				"key" : "label2",
-				"value" : "value2",
+				"key":   "label2",
+				"value": "value2",
 			},
 			common.MapStr{
-				"key" : "label3_with_dots",
-				"value" : "value3",
+				"key":   "label3_with_dots",
+				"value": "value3",
 			},
 		},
-		"dockerSocket":  &socket,
+		"dockerSocket": &socket,
 		"container": common.MapStr{
 			"id":      container.ID,
 			"command": container.Command,
@@ -709,19 +709,19 @@ func TestEventGeneratorGetContainerEventWithNoPorts(t *testing.T) {
 		"containerName": "name1",
 		"containerLabels": []common.MapStr{
 			common.MapStr{
-				"key" : "label1",
-				"value" : "value1",
+				"key":   "label1",
+				"value": "value1",
 			},
 			common.MapStr{
-				"key" : "label2",
-				"value" : "value2",
+				"key":   "label2",
+				"value": "value2",
 			},
 			common.MapStr{
-				"key" : "label3_with_dots",
-				"value" : "value3",
+				"key":   "label3_with_dots",
+				"value": "value3",
 			},
 		},
-		"dockerSocket":  &socket,
+		"dockerSocket": &socket,
 		"container": common.MapStr{
 			"id":         container.ID,
 			"command":    container.Command,
@@ -817,15 +817,15 @@ func TestEventGeneratorGetCpuEvent(t *testing.T) {
 		"containerName": "name1",
 		"containerLabels": []common.MapStr{
 			common.MapStr{
-				"key" : "label1",
-				"value" : "value1",
+				"key":   "label1",
+				"value": "value1",
 			},
 			common.MapStr{
-				"key" : "label2",
-				"value" : "value2",
+				"key":   "label2",
+				"value": "value2",
 			},
 		},
-		"dockerSocket":  &socket,
+		"dockerSocket": &socket,
 		"cpu": common.MapStr{
 			"percpuUsage":       mockedCPUCalculator.PerCpuUsage(),
 			"totalUsage":        mockedCPUCalculator.TotalUsage(),
@@ -887,15 +887,15 @@ func TestEventGeneratorGetMemoryEvent(t *testing.T) {
 		"containerName": "name1",
 		"containerLabels": []common.MapStr{
 			common.MapStr{
-				"key" : "label1",
-				"value" : "value1",
+				"key":   "label1",
+				"value": "value1",
 			},
 			common.MapStr{
-				"key" : "label2",
-				"value" : "value2",
+				"key":   "label2",
+				"value": "value2",
 			},
 		},
-		"dockerSocket":  &socket,
+		"dockerSocket": &socket,
 		"memory": common.MapStr{
 			"failcnt":    stats.MemoryStats.Failcnt,
 			"limit":      stats.MemoryStats.Limit,
@@ -984,15 +984,15 @@ func TestEventGeneratorGetBlkioEventFirstPass(t *testing.T) {
 		"containerName": "name1",
 		"containerLabels": []common.MapStr{
 			common.MapStr{
-				"key" : "label1",
-				"value" : "value1",
+				"key":   "label1",
+				"value": "value1",
 			},
 			common.MapStr{
-				"key" : "label2",
-				"value" : "value2",
+				"key":   "label2",
+				"value": "value2",
 			},
 		},
-		"dockerSocket":  &socket,
+		"dockerSocket": &socket,
 		"blkio": common.MapStr{
 			"read_ps":  float64(0),
 			"write_ps": float64(0),
@@ -1087,15 +1087,15 @@ func TestEventGeneratorGetBlkioEvent(t *testing.T) {
 		"containerName": "name1",
 		"containerLabels": []common.MapStr{
 			common.MapStr{
-				"key" : "label1",
-				"value" : "value1",
+				"key":   "label1",
+				"value": "value1",
 			},
 			common.MapStr{
-				"key" : "label2",
-				"value" : "value2",
+				"key":   "label2",
+				"value": "value2",
 			},
 		},
-		"dockerSocket":  &socket,
+		"dockerSocket": &socket,
 		"blkio": common.MapStr{
 			"read_ps":  mockedBlkioCalculator.GetReadPs(),
 			"write_ps": mockedBlkioCalculator.GetWritePs(),
@@ -1199,15 +1199,15 @@ func TestEventGeneratorGetBlkioEventCleanSavedEvents(t *testing.T) {
 		"containerName": "name1",
 		"containerLabels": []common.MapStr{
 			common.MapStr{
-				"key" : "label1",
-				"value" : "value1",
+				"key":   "label1",
+				"value": "value1",
 			},
 			common.MapStr{
-				"key" : "label2",
-				"value" : "value2",
+				"key":   "label2",
+				"value": "value2",
 			},
 		},
-		"dockerSocket":  &socket,
+		"dockerSocket": &socket,
 		"blkio": common.MapStr{
 			"read_ps":  mockedBlkioCalculator.GetReadPs(),
 			"write_ps": mockedBlkioCalculator.GetWritePs(),
@@ -1277,37 +1277,37 @@ func TestEventGeneratorGetLogEvent(t *testing.T) {
 // NEEDED TYPES
 
 type MemoryStats struct {
-	Stats    struct {
-			 TotalPgmafault          uint64 `json:"total_pgmafault,omitempty" yaml:"total_pgmafault,omitempty"`
-			 Cache                   uint64 `json:"cache,omitempty" yaml:"cache,omitempty"`
-			 MappedFile              uint64 `json:"mapped_file,omitempty" yaml:"mapped_file,omitempty"`
-			 TotalInactiveFile       uint64 `json:"total_inactive_file,omitempty" yaml:"total_inactive_file,omitempty"`
-			 Pgpgout                 uint64 `json:"pgpgout,omitempty" yaml:"pgpgout,omitempty"`
-			 Rss                     uint64 `json:"rss,omitempty" yaml:"rss,omitempty"`
-			 TotalMappedFile         uint64 `json:"total_mapped_file,omitempty" yaml:"total_mapped_file,omitempty"`
-			 Writeback               uint64 `json:"writeback,omitempty" yaml:"writeback,omitempty"`
-			 Unevictable             uint64 `json:"unevictable,omitempty" yaml:"unevictable,omitempty"`
-			 Pgpgin                  uint64 `json:"pgpgin,omitempty" yaml:"pgpgin,omitempty"`
-			 TotalUnevictable        uint64 `json:"total_unevictable,omitempty" yaml:"total_unevictable,omitempty"`
-			 Pgmajfault              uint64 `json:"pgmajfault,omitempty" yaml:"pgmajfault,omitempty"`
-			 TotalRss                uint64 `json:"total_rss,omitempty" yaml:"total_rss,omitempty"`
-			 TotalRssHuge            uint64 `json:"total_rss_huge,omitempty" yaml:"total_rss_huge,omitempty"`
-			 TotalWriteback          uint64 `json:"total_writeback,omitempty" yaml:"total_writeback,omitempty"`
-			 TotalInactiveAnon       uint64 `json:"total_inactive_anon,omitempty" yaml:"total_inactive_anon,omitempty"`
-			 RssHuge                 uint64 `json:"rss_huge,omitempty" yaml:"rss_huge,omitempty"`
-			 HierarchicalMemoryLimit uint64 `json:"hierarchical_memory_limit,omitempty" yaml:"hierarchical_memory_limit,omitempty"`
-			 TotalPgfault            uint64 `json:"total_pgfault,omitempty" yaml:"total_pgfault,omitempty"`
-			 TotalActiveFile         uint64 `json:"total_active_file,omitempty" yaml:"total_active_file,omitempty"`
-			 ActiveAnon              uint64 `json:"active_anon,omitempty" yaml:"active_anon,omitempty"`
-			 TotalActiveAnon         uint64 `json:"total_active_anon,omitempty" yaml:"total_active_anon,omitempty"`
-			 TotalPgpgout            uint64 `json:"total_pgpgout,omitempty" yaml:"total_pgpgout,omitempty"`
-			 TotalCache              uint64 `json:"total_cache,omitempty" yaml:"total_cache,omitempty"`
-			 InactiveAnon            uint64 `json:"inactive_anon,omitempty" yaml:"inactive_anon,omitempty"`
-			 ActiveFile              uint64 `json:"active_file,omitempty" yaml:"active_file,omitempty"`
-			 Pgfault                 uint64 `json:"pgfault,omitempty" yaml:"pgfault,omitempty"`
-			 InactiveFile            uint64 `json:"inactive_file,omitempty" yaml:"inactive_file,omitempty"`
-			 TotalPgpgin             uint64 `json:"total_pgpgin,omitempty" yaml:"total_pgpgin,omitempty"`
-		 } `json:"stats,omitempty" yaml:"stats,omitempty"`
+	Stats struct {
+		TotalPgmafault          uint64 `json:"total_pgmafault,omitempty" yaml:"total_pgmafault,omitempty"`
+		Cache                   uint64 `json:"cache,omitempty" yaml:"cache,omitempty"`
+		MappedFile              uint64 `json:"mapped_file,omitempty" yaml:"mapped_file,omitempty"`
+		TotalInactiveFile       uint64 `json:"total_inactive_file,omitempty" yaml:"total_inactive_file,omitempty"`
+		Pgpgout                 uint64 `json:"pgpgout,omitempty" yaml:"pgpgout,omitempty"`
+		Rss                     uint64 `json:"rss,omitempty" yaml:"rss,omitempty"`
+		TotalMappedFile         uint64 `json:"total_mapped_file,omitempty" yaml:"total_mapped_file,omitempty"`
+		Writeback               uint64 `json:"writeback,omitempty" yaml:"writeback,omitempty"`
+		Unevictable             uint64 `json:"unevictable,omitempty" yaml:"unevictable,omitempty"`
+		Pgpgin                  uint64 `json:"pgpgin,omitempty" yaml:"pgpgin,omitempty"`
+		TotalUnevictable        uint64 `json:"total_unevictable,omitempty" yaml:"total_unevictable,omitempty"`
+		Pgmajfault              uint64 `json:"pgmajfault,omitempty" yaml:"pgmajfault,omitempty"`
+		TotalRss                uint64 `json:"total_rss,omitempty" yaml:"total_rss,omitempty"`
+		TotalRssHuge            uint64 `json:"total_rss_huge,omitempty" yaml:"total_rss_huge,omitempty"`
+		TotalWriteback          uint64 `json:"total_writeback,omitempty" yaml:"total_writeback,omitempty"`
+		TotalInactiveAnon       uint64 `json:"total_inactive_anon,omitempty" yaml:"total_inactive_anon,omitempty"`
+		RssHuge                 uint64 `json:"rss_huge,omitempty" yaml:"rss_huge,omitempty"`
+		HierarchicalMemoryLimit uint64 `json:"hierarchical_memory_limit,omitempty" yaml:"hierarchical_memory_limit,omitempty"`
+		TotalPgfault            uint64 `json:"total_pgfault,omitempty" yaml:"total_pgfault,omitempty"`
+		TotalActiveFile         uint64 `json:"total_active_file,omitempty" yaml:"total_active_file,omitempty"`
+		ActiveAnon              uint64 `json:"active_anon,omitempty" yaml:"active_anon,omitempty"`
+		TotalActiveAnon         uint64 `json:"total_active_anon,omitempty" yaml:"total_active_anon,omitempty"`
+		TotalPgpgout            uint64 `json:"total_pgpgout,omitempty" yaml:"total_pgpgout,omitempty"`
+		TotalCache              uint64 `json:"total_cache,omitempty" yaml:"total_cache,omitempty"`
+		InactiveAnon            uint64 `json:"inactive_anon,omitempty" yaml:"inactive_anon,omitempty"`
+		ActiveFile              uint64 `json:"active_file,omitempty" yaml:"active_file,omitempty"`
+		Pgfault                 uint64 `json:"pgfault,omitempty" yaml:"pgfault,omitempty"`
+		InactiveFile            uint64 `json:"inactive_file,omitempty" yaml:"inactive_file,omitempty"`
+		TotalPgpgin             uint64 `json:"total_pgpgin,omitempty" yaml:"total_pgpgin,omitempty"`
+	} `json:"stats,omitempty" yaml:"stats,omitempty"`
 	MaxUsage uint64 `json:"max_usage,omitempty" yaml:"max_usage,omitempty"`
 	Usage    uint64 `json:"usage,omitempty" yaml:"usage,omitempty"`
 	Failcnt  uint64 `json:"failcnt,omitempty" yaml:"failcnt,omitempty"`
@@ -1374,39 +1374,39 @@ func getMockedCPUCalculator(number float64) calculator.CPUCalculator {
 
 func getMemoryStats(read time.Time, number uint64) docker.Stats {
 	type memoryStats struct {
-		Stats    struct {
-				 TotalPgmafault          uint64 `json:"total_pgmafault,omitempty" yaml:"total_pgmafault,omitempty"`
-				 Cache                   uint64 `json:"cache,omitempty" yaml:"cache,omitempty"`
-				 MappedFile              uint64 `json:"mapped_file,omitempty" yaml:"mapped_file,omitempty"`
-				 TotalInactiveFile       uint64 `json:"total_inactive_file,omitempty" yaml:"total_inactive_file,omitempty"`
-				 Pgpgout                 uint64 `json:"pgpgout,omitempty" yaml:"pgpgout,omitempty"`
-				 Rss                     uint64 `json:"rss,omitempty" yaml:"rss,omitempty"`
-				 TotalMappedFile         uint64 `json:"total_mapped_file,omitempty" yaml:"total_mapped_file,omitempty"`
-				 Writeback               uint64 `json:"writeback,omitempty" yaml:"writeback,omitempty"`
-				 Unevictable             uint64 `json:"unevictable,omitempty" yaml:"unevictable,omitempty"`
-				 Pgpgin                  uint64 `json:"pgpgin,omitempty" yaml:"pgpgin,omitempty"`
-				 TotalUnevictable        uint64 `json:"total_unevictable,omitempty" yaml:"total_unevictable,omitempty"`
-				 Pgmajfault              uint64 `json:"pgmajfault,omitempty" yaml:"pgmajfault,omitempty"`
-				 TotalRss                uint64 `json:"total_rss,omitempty" yaml:"total_rss,omitempty"`
-				 TotalRssHuge            uint64 `json:"total_rss_huge,omitempty" yaml:"total_rss_huge,omitempty"`
-				 TotalWriteback          uint64 `json:"total_writeback,omitempty" yaml:"total_writeback,omitempty"`
-				 TotalInactiveAnon       uint64 `json:"total_inactive_anon,omitempty" yaml:"total_inactive_anon,omitempty"`
-				 RssHuge                 uint64 `json:"rss_huge,omitempty" yaml:"rss_huge,omitempty"`
-				 HierarchicalMemoryLimit uint64 `json:"hierarchical_memory_limit,omitempty" yaml:"hierarchical_memory_limit,omitempty"`
-				 TotalPgfault            uint64 `json:"total_pgfault,omitempty" yaml:"total_pgfault,omitempty"`
-				 TotalActiveFile         uint64 `json:"total_active_file,omitempty" yaml:"total_active_file,omitempty"`
-				 ActiveAnon              uint64 `json:"active_anon,omitempty" yaml:"active_anon,omitempty"`
-				 TotalActiveAnon         uint64 `json:"total_active_anon,omitempty" yaml:"total_active_anon,omitempty"`
-				 TotalPgpgout            uint64 `json:"total_pgpgout,omitempty" yaml:"total_pgpgout,omitempty"`
-				 TotalCache              uint64 `json:"total_cache,omitempty" yaml:"total_cache,omitempty"`
-				 InactiveAnon            uint64 `json:"inactive_anon,omitempty" yaml:"inactive_anon,omitempty"`
-				 ActiveFile              uint64 `json:"active_file,omitempty" yaml:"active_file,omitempty"`
-				 Pgfault                 uint64 `json:"pgfault,omitempty" yaml:"pgfault,omitempty"`
-				 InactiveFile            uint64 `json:"inactive_file,omitempty" yaml:"inactive_file,omitempty"`
-				 TotalPgpgin             uint64 `json:"total_pgpgin,omitempty" yaml:"total_pgpgin,omitempty"`
-				 HierarchicalMemswLimit  uint64 `json:"hierarchical_memsw_limit,omitempty" yaml:"hierarchical_memsw_limit,omitempty"`
-				 Swap                    uint64 `json:"swap,omitempty" yaml:"swap,omitempty"`
-			 } `json:"stats,omitempty" yaml:"stats,omitempty"`
+		Stats struct {
+			TotalPgmafault          uint64 `json:"total_pgmafault,omitempty" yaml:"total_pgmafault,omitempty"`
+			Cache                   uint64 `json:"cache,omitempty" yaml:"cache,omitempty"`
+			MappedFile              uint64 `json:"mapped_file,omitempty" yaml:"mapped_file,omitempty"`
+			TotalInactiveFile       uint64 `json:"total_inactive_file,omitempty" yaml:"total_inactive_file,omitempty"`
+			Pgpgout                 uint64 `json:"pgpgout,omitempty" yaml:"pgpgout,omitempty"`
+			Rss                     uint64 `json:"rss,omitempty" yaml:"rss,omitempty"`
+			TotalMappedFile         uint64 `json:"total_mapped_file,omitempty" yaml:"total_mapped_file,omitempty"`
+			Writeback               uint64 `json:"writeback,omitempty" yaml:"writeback,omitempty"`
+			Unevictable             uint64 `json:"unevictable,omitempty" yaml:"unevictable,omitempty"`
+			Pgpgin                  uint64 `json:"pgpgin,omitempty" yaml:"pgpgin,omitempty"`
+			TotalUnevictable        uint64 `json:"total_unevictable,omitempty" yaml:"total_unevictable,omitempty"`
+			Pgmajfault              uint64 `json:"pgmajfault,omitempty" yaml:"pgmajfault,omitempty"`
+			TotalRss                uint64 `json:"total_rss,omitempty" yaml:"total_rss,omitempty"`
+			TotalRssHuge            uint64 `json:"total_rss_huge,omitempty" yaml:"total_rss_huge,omitempty"`
+			TotalWriteback          uint64 `json:"total_writeback,omitempty" yaml:"total_writeback,omitempty"`
+			TotalInactiveAnon       uint64 `json:"total_inactive_anon,omitempty" yaml:"total_inactive_anon,omitempty"`
+			RssHuge                 uint64 `json:"rss_huge,omitempty" yaml:"rss_huge,omitempty"`
+			HierarchicalMemoryLimit uint64 `json:"hierarchical_memory_limit,omitempty" yaml:"hierarchical_memory_limit,omitempty"`
+			TotalPgfault            uint64 `json:"total_pgfault,omitempty" yaml:"total_pgfault,omitempty"`
+			TotalActiveFile         uint64 `json:"total_active_file,omitempty" yaml:"total_active_file,omitempty"`
+			ActiveAnon              uint64 `json:"active_anon,omitempty" yaml:"active_anon,omitempty"`
+			TotalActiveAnon         uint64 `json:"total_active_anon,omitempty" yaml:"total_active_anon,omitempty"`
+			TotalPgpgout            uint64 `json:"total_pgpgout,omitempty" yaml:"total_pgpgout,omitempty"`
+			TotalCache              uint64 `json:"total_cache,omitempty" yaml:"total_cache,omitempty"`
+			InactiveAnon            uint64 `json:"inactive_anon,omitempty" yaml:"inactive_anon,omitempty"`
+			ActiveFile              uint64 `json:"active_file,omitempty" yaml:"active_file,omitempty"`
+			Pgfault                 uint64 `json:"pgfault,omitempty" yaml:"pgfault,omitempty"`
+			InactiveFile            uint64 `json:"inactive_file,omitempty" yaml:"inactive_file,omitempty"`
+			TotalPgpgin             uint64 `json:"total_pgpgin,omitempty" yaml:"total_pgpgin,omitempty"`
+			HierarchicalMemswLimit  uint64 `json:"hierarchical_memsw_limit,omitempty" yaml:"hierarchical_memsw_limit,omitempty"`
+			Swap                    uint64 `json:"swap,omitempty" yaml:"swap,omitempty"`
+		} `json:"stats,omitempty" yaml:"stats,omitempty"`
 		MaxUsage uint64 `json:"max_usage,omitempty" yaml:"max_usage,omitempty"`
 		Usage    uint64 `json:"usage,omitempty" yaml:"usage,omitempty"`
 		Failcnt  uint64 `json:"failcnt,omitempty" yaml:"failcnt,omitempty"`


### PR DESCRIPTION
This PR adds labels for all dockerbeat stats.

In addition, label format changes. It is now an array of object rather than a map (easier to manage with elasticsearch).

This PR is related to the #101 reported by @hlepesant